### PR TITLE
JsonArray's should be converted back to a List on the receiving side.

### DIFF
--- a/src/main/groovy/org/vertx/groovy/core/eventbus/Message.groovy
+++ b/src/main/groovy/org/vertx/groovy/core/eventbus/Message.groovy
@@ -19,6 +19,7 @@ package org.vertx.groovy.core.eventbus
 import groovy.transform.CompileStatic;
 
 import org.vertx.java.core.eventbus.Message as JMessage
+import org.vertx.java.core.json.JsonArray
 import org.vertx.java.core.json.JsonObject
 
 /**
@@ -47,7 +48,9 @@ class Message {
 
   Message(JMessage jMessage) {
     if (jMessage.body() instanceof JsonObject) {
-      this.body = jMessage.body().toMap()
+      this.body = ((JsonObject) jMessage.body()).toMap()
+    } else if (jMessage.body() instanceof JsonArray) {
+      this.body = ((JsonArray) jMessage.body()).toList()
     } else {
       this.body = jMessage.body()
     }

--- a/src/test/groovy_scripts/core/eventbus/testClient.groovy
+++ b/src/test/groovy_scripts/core/eventbus/testClient.groovy
@@ -53,14 +53,13 @@ shortTimeout = 1L
 longTimeout = 5000L
 
 def assertSent(msg) {
-  tu.azzert(sent['price'] == msg['price'])
-  tu.azzert(sent['name'] == msg['name'])
+  tu.azzert(msg instanceof Map)
+  tu.azzert(msg.equals(sent));
 }
 
 def assertSentList(msg) {
-    sentList.eachWithIndex { def entry, int i ->
-        tu.azzert(entry == msg[i])
-    }
+    tu.azzert(msg instanceof List)
+    tu.azzert(msg.equals(sentList));
 }
 def assertSentGString(msg) {
     tu.azzert(sentGString.toString() == msg)


### PR DESCRIPTION
So I noticed that we convert from List to JsonArray when sending, but back on the receiving side we do not. Surely if I send a List over the EventBus I should get a List back ? 

However it should be noted this could possibly break existing code if they do indeed expect a JsonArray on the receiving side. 

This is more in line with how we treat JsonObject -> Map as well.
